### PR TITLE
Add issue template for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: 🐞 Bug report
+about: Informar un error o problema
+title: "[BUG] "
+labels: bug
+assignees: ''
+
+---
+
+## 🐛 Descripción
+
+Explicá brevemente el error o comportamiento inesperado.
+
+## 🔁 Pasos para reproducir
+
+1. Ir a '...'
+2. Hacer click en '...'
+3. Observar '...'
+
+## ✅ Comportamiento esperado
+
+Contanos qué debería pasar normalmente.
+
+## 🖼️ Capturas de pantalla
+
+Si aplica, agregá capturas para entender mejor el problema.
+
+## 🧪 Ambiente
+
+- Sistema operativo:
+- Navegador o entorno:
+- Versión del proyecto:


### PR DESCRIPTION
This pull request adds a standardized issue template for reporting bugs to the `.github/ISSUE_TEMPLATE/` directory. The goal is to encourage clear and consistent bug reports from contributors or users, helping us streamline debugging and issue resolution.

The template includes:
- A clear structure for reproducing bugs
- Fields for expected behavior and screenshots
- A dedicated section for any extra context

This contributes to the professionalization of the repository and supports future community or team collaboration.

✅ Ready to merge.
